### PR TITLE
Fix error in `time-ago-description`

### DIFF
--- a/src/tofu/utils.clj
+++ b/src/tofu/utils.clj
@@ -17,5 +17,5 @@
       1    "just now"
       60    (str delta-secs " second(s) ago")
       3600  (str (-> delta-secs (/ 60) int) " minute(s) ago")
-      62400 (str (-> delta-secs (/ 3600) int) " hour(s) ago")
-            (str (-> delta-secs (/ 62400) int) " day(s) ago"))))
+      86400 (str (-> delta-secs (/ 3600) int) " hour(s) ago")
+            (str (-> delta-secs (/ 86400) int) " day(s) ago"))))


### PR DESCRIPTION
There are 86400 seconds per day: 3600 \* 24
Perhaps the 62400 came from a typo: 2600 \* 24
